### PR TITLE
Mention the new % unit for maxBytes and maxPhysicalBytes in the Memor…

### DIFF
--- a/docs/_100-beta2/deeplearning4j-config-memory.md
+++ b/docs/_100-beta2/deeplearning4j-config-memory.md
@@ -30,9 +30,9 @@ With DL4J/ND4J, there are two types of memory limits to be aware of and configur
 
 * `-Xmx` - this allows you to specify JVM heap memory limit (maximum, at any point). Only allocated up to this amount (at the discretion of the JVM) if required.
 
-* `-Dorg.bytedeco.javacpp.maxbytes`  - this allows you to specify the off-heap memory limit.
+* `-Dorg.bytedeco.javacpp.maxbytes`  - this allows you to specify the off-heap memory limit. This can also be a percentage, in which case it would apply to maxMemory.
 
-* `-Dorg.bytedeco.javacpp.maxphysicalbytes` - also for off-heap, this usually should be set equal to `maxbytes`.
+* `-Dorg.bytedeco.javacpp.maxphysicalbytes` - also for off-heap, this usually should be set equal to `maxbytes`. This can also be a percentage (>100%), in which case it would apply to maxMemory.
 
 Example: Configuring 1GB initial on-heap, 2GB max on-heap, 8GB off-heap:
 


### PR DESCRIPTION
I was suprised to not find this new javacpp feature not mentioned in the docs. The change was done a few months ago over here: https://github.com/eclipse/deeplearning4j/commit/ca207636192efa0b1b9c6e1ebf754183a9d52783

But it appears to have been lost in the transition. I contacted Samuel Audet who suggested I create a new PR, so here it is.